### PR TITLE
fix data import & add CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+# stolen from https://github.com/khcrysalis/Feather/blob/5a7456447205fb1bea4e783ec066ee3dedd6a893/.github/workflows/release.yml
+name: Create New Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Compile Journal
+        run: |
+          make
+
+      - name: Get Version
+        id: get_version
+        run: |
+          VERSION=$(cat packages/version.txt)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: PsychonautWiki Journal v${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
+          files: |
+            packages/*ipa
+          fail_on_unmatched_files: true
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ DerivedData/
 
 ## Gcc Patch
 /*.gcno
+
+.DS_Store
+packages

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# stolen from https://github.com/khcrysalis/Feather/blob/5a7456447205fb1bea4e783ec066ee3dedd6a893/Makefile
+NAME := PsychonautWiki Journal
+APPNAME := Journal
+PLATFORM := iphoneos
+
+TMP := $(TMPDIR)/$(APPNAME)
+ARCHIVE := $(TMP)/archive.xcarchive
+IPA := packages/$(APPNAME)-unsigned.ipa
+
+.PHONY: all clean archive ipa
+
+all: ipa
+
+clean:
+	rm -rf "$(TMP)" "packages"
+
+archive:
+	rm -rf "$(ARCHIVE)"
+	xcodebuild archive \
+	    -project "$(NAME).xcodeproj" \
+	    -scheme "$(NAME)" \
+	    -configuration Release \
+	    -sdk $(PLATFORM) \
+	    -archivePath "$(ARCHIVE)" \
+	    -skipPackagePluginValidation \
+	    CODE_SIGN_IDENTITY="" \
+	    CODE_SIGNING_REQUIRED=NO \
+	    CODE_SIGNING_ALLOWED=NO \
+	    ARCHS=arm64 VALID_ARCHS=arm64 \
+	    DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
+	    STRIP_INSTALLED_PRODUCT=YES \
+	    ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=NO
+
+ipa: archive
+	rm -rf "$(TMP)/Payload"
+	mkdir -p "$(TMP)/Payload"
+	cp -R "$(ARCHIVE)/Products/Applications/$(APPNAME).app" "$(TMP)/Payload/"
+
+	mkdir -p "$(dir $(IPA))"
+
+	/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$(TMP)/Payload/$(APPNAME).app/Info.plist" > "$(dir $(IPA))/version.txt"
+
+	cd "$(TMP)" && zip -r9 -y -q "$(abspath $(IPA))" Payload


### PR DESCRIPTION
Replaced the modern fileImporter with this ugly wrapper that allows setting asCopy to true.
This is needed to make data import work when installed via sideloading methods that result in a mismatch between bundle ID and app ID.

Also set up a CI workflow on the hosted GH runners for comfort and transparency.